### PR TITLE
Add ProductDb class with basic method stubs

### DIFF
--- a/Test/ProductDb.cs
+++ b/Test/ProductDb.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test;
+class ProductDb
+{
+    public List<string> GetAllProducts()
+    {
+        throw new NotImplementedException();
+    }
+
+    public string GetProduct(int id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void AddProduct(string product)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void UpdateProduct(int id, string product)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void DeleteProduct(int id)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Introduced a new `ProductDb` class in the `Test` namespace. This class contains five methods: `GetAllProducts`, `GetProduct`, `AddProduct`, `UpdateProduct`, and `DeleteProduct`, all of which currently throw a `NotImplementedException`. Added necessary using directives at the top of the file.